### PR TITLE
Handle npm install failures gracefully in dotfiles

### DIFF
--- a/.chezmoiscripts/run_once_install-claude-code.sh
+++ b/.chezmoiscripts/run_once_install-claude-code.sh
@@ -3,7 +3,16 @@
 # Install Claude Code CLI if npm is available
 if command -v npm &> /dev/null; then
     echo "Installing @anthropic-ai/claude-code..."
-    npm install -g @anthropic-ai/claude-code
+    if npm install -g @anthropic-ai/claude-code; then
+        echo "Successfully installed @anthropic-ai/claude-code"
+    else
+        echo "WARNING: Failed to install @anthropic-ai/claude-code"
+        echo "This may be due to permission issues. You can try installing it manually with:"
+        echo "  sudo npm install -g @anthropic-ai/claude-code"
+        echo "or:"
+        echo "  npm install -g @anthropic-ai/claude-code --prefix ~/.local"
+        echo "Continuing with dotfiles installation..."
+    fi
 else
     echo "npm not found, skipping Claude Code installation"
 fi


### PR DESCRIPTION
The npm install for Claude Code can fail due to permission issues, which was causing the entire dotfiles installation to fail. This change makes the failure non-fatal by:

- Checking the exit status of npm install
- Showing a warning with helpful instructions if it fails
- Continuing with the rest of the dotfiles installation

This prevents one optional tool from blocking the entire setup process.